### PR TITLE
Fix #35

### DIFF
--- a/code-prettify.php
+++ b/code-prettify.php
@@ -46,7 +46,7 @@ function add_prettify_scripts() {
 	wp_localize_script(
 		'code-prettify',
 		'codePrettifyLoaderBaseUrl',
-		plugins_url( 'prettify', __FILE__ )
+		[ plugins_url( 'prettify', __FILE__ ) ]
 	);
 
 	add_action( 'wp_head', 'prettify_preload_code_styles' );


### PR DESCRIPTION
Fixes the notice:
WP_Scripts::localize was called incorrectly. The $l10n parameter must be an array. To pass arbitrary data to scripts, use the wp_add_inline_script() function instead.

This notice appears as from WordPress 5.7.0